### PR TITLE
Fix potential token expired issue and missing link field from TDR search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+v0.1.4
+- Fix issue with a token that has potentially expired, when there is a time between the token validation and the use of the token.
+- Fix issue with returned TDR search result, where link is not always returned (e.g. when also supplying _id in the query parameters)
+
 v0.1.3
 - Fix issue for a path that already contains query parameters
 

--- a/DotnetHsdpSdk/IAM/Internal/Models.cs
+++ b/DotnetHsdpSdk/IAM/Internal/Models.cs
@@ -32,7 +32,7 @@ internal class IamToken : IIamToken
 
     public bool IsExpired()
     {
-        return ExpiresUtc < DateTime.UtcNow;
+        return ExpiresUtc < DateTime.UtcNow + TimeSpan.FromSeconds(30);
     }
 
     public bool IsValid()

--- a/DotnetHsdpSdk/TDR/Internal/TdrResponseFactory.cs
+++ b/DotnetHsdpSdk/TDR/Internal/TdrResponseFactory.cs
@@ -20,8 +20,8 @@ internal class TdrResponseFactory : ITdrResponseFactory
             throw new HsdpRequestException(hsdpResponse.StatusCode, hsdpResponse.Body);
 
         var response = Deserialize<BundleForGetDataItemResponse>(hsdpResponse.Body);
-        if (response.entry == null || response.link == null)
-            throw new HsdpRequestException(InternalApiError.StatusCode, "Response has wrong format");
+        if (response.entry == null)
+            throw new HsdpRequestException(InternalApiError.StatusCode, "Response has no entries");
         var requestId = hsdpResponse.Headers.Find(header => header.Key.ToLower() == "hsdp-request-id").Value;
         return new TdrSearchDataResponse
         {


### PR DESCRIPTION
- Keep a bit of time (30 seconds) between the current time and the time of token expiry so we can cope with a bit of delay between checking the validity of the token and the actual use of the token
- When searching for a data item with the id included in the query parameters, then the link field will not be returned